### PR TITLE
Fix a bug where the sim time request failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
+## Latest
+
+### General
+
+- Fixed a problem where the simulated time request was not correctly handled while using subprocess and failed
+
+### plankton_utils
+
+-Increased the default timeout for sim time request to 10s
+
 ## 0.5.2
 
 ### uuv_sensor_ros_plugins
 
--Updated deprecated remapping syntax warnings occuring in URDF files
+- Updated deprecated remapping syntax warnings occuring in URDF files
 
 ## 0.5.1
 


### PR DESCRIPTION
Previously, when many nodes were launched at the same time, including the global node responsible for the sim time value, a sim time request based on subprocess could fail. The function making the request has been changed accordingly.