### PR TITLE
Remove apostrophes in comments to workaround ros2/launch_ros#214

### DIFF
--- a/uuv_descriptions/urdf/rexrov_base.xacro
+++ b/uuv_descriptions/urdf/rexrov_base.xacro
@@ -85,7 +85,7 @@
     <!-- Set up hydrodynamic plugin given as input parameter -->
     <xacro:insert_block name="gazebo"/>
 
-    <!-- optional: plugin to test compare Gazebo's returned accelerations
+    <!-- optional: plugin to test compare Gazebo returned accelerations
     <gazebo>
       <plugin name="${namespace}_test_plugin" filename="libuuv_accelerations_test_plugin.so">
         <link_name>${namespace}/base_link</link_name>

--- a/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/urdf/thruster_snippets.xacro
+++ b/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/urdf/thruster_snippets.xacro
@@ -13,7 +13,7 @@
   </xacro:macro>
 
   <!--
-    MACROS FOR CONVERSION FUNCTIONS BETWEEN ROTOR'S ANG. VELOCITY AND
+    MACROS FOR CONVERSION FUNCTIONS BETWEEN ROTORS ANG. VELOCITY AND
     THRUSTER FORCE
   -->
 
@@ -60,8 +60,8 @@
 
   <!--
     3) Linear interpolation
-      If you have access to the thruster's data sheet, for example,
-      you can enter samples of the curve's input and output values
+      If you have access to the thruster data sheet, for example,
+      you can enter samples of the curve input and output values
       and the thruster output will be found through linear interpolation
       of the given samples.
   -->
@@ -128,7 +128,7 @@
 
   <!--
     Thruster model with first order dynamic model for the rotor dynamics
-    and a proportional non-linear steady-state conversion from the rotor's
+    and a proportional non-linear steady-state conversion from the rotor
     angular velocity to output thrust force
   -->
 

--- a/uuv_tutorials/uuv_tutorial_rov_model/robots/rov_example_default.xacro
+++ b/uuv_tutorials/uuv_tutorial_rov_model/robots/rov_example_default.xacro
@@ -26,7 +26,7 @@
   <!-- Input debug flag -->
   <xacro:arg name="debug" default="0"/>
 
-  <!-- Vehicle's namespace -->
+  <!-- Vehicle namespace -->
   <xacro:arg name="namespace" default="rov_example"/>
 
   <!-- Include the ROV macro file -->

--- a/uuv_tutorials/uuv_tutorial_rov_model/urdf/rov_example_base.xacro
+++ b/uuv_tutorials/uuv_tutorial_rov_model/urdf/rov_example_base.xacro
@@ -26,11 +26,11 @@
   <xacro:include filename="$(find uuv_descriptions)/urdf/common.urdf.xacro"/>
   <!-- Loading file with sensor macros -->
   <xacro:include filename="$(find uuv_sensor_ros_plugins)/urdf/sensor_snippets.xacro"/>
-  <!-- Loading vehicle's specific macros -->
+  <!-- Loading vehicle specific macros -->
   <xacro:include filename="$(find uuv_tutorial_rov_model)/urdf/rov_example_snippets.xacro"/>
 
   <!--
-    Vehicle's parameters (remember to enter the model parameters below)
+    Vehicle parameters (remember to enter the model parameters below)
   -->
 
   <xacro:property name="mass" value="0"/>
@@ -42,7 +42,7 @@
   <!-- Fluid density -->
   <xacro:property name="rho" value="1028"/>
 
-  <!-- Describing the dimensions of the vehicle's bounding box -->
+  <!-- Describing the dimensions of the vehicle bounding box -->
   <xacro:property name="length" value="0"/>
   <xacro:property name="width"  value="0"/>
   <xacro:property name="height" value="0"/>
@@ -118,15 +118,15 @@
         forces and moments will be published in separate topics -->
         <debug>${debug}</debug>
 
-        <!-- List of hydrodynamic models this robot's links -->
+        <!-- List of hydrodynamic models this robot links -->
         <link name="${namespace}/base_link">
           <!-- This flag will make the link neutrally buoyant -->
           <neutrally_buoyant>0</neutrally_buoyant>
 
-          <!-- Link's volume -->
+          <!-- Link volume -->
           <volume>${volume}</volume>
 
-          <!-- Link's bounding box, it is used to recalculate the immersed
+          <!-- Link bounding box, it is used to recalculate the immersed
           volume when close to the surface.
           This is a workaround the invalid bounding box given by Gazebo-->
           <box>
@@ -142,7 +142,7 @@
           ----------------------------------------------------
           ----------------------------------------------------
           Choose one of the hydrodynamic models below, all are based on
-          Fossen's equation of motion for underwater vehicles
+          Fossen equation of motion for underwater vehicles
 
           Reference:
           [1] Fossen, Thor I. Handbook of marine craft hydrodynamics and motion
@@ -150,7 +150,7 @@
           ----------------------------------------------------
           ---------------------------------------------------->
 
-          <!-- Fossen's equation of motion -->
+          <!-- Fossen equation of motion -->
           <hydrodynamic_model>
             <type>fossen</type>
             <added_mass>

--- a/uuv_tutorials/uuv_tutorial_rov_model/urdf/rov_example_snippets.xacro
+++ b/uuv_tutorials/uuv_tutorial_rov_model/urdf/rov_example_snippets.xacro
@@ -24,7 +24,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- Provide the propeller mesh in a separate file with the rotation axis
-  over propeller's frame X-axis in DAE (Collada) or STL format.
+  over propeller frame X-axis in DAE (Collada) or STL format.
   -->
   <xacro:property name="prop_mesh_file" value="file://$(find uuv_tutorial_rov_model)/mesh/propeller.dae"/>
 
@@ -116,7 +116,7 @@
           <timeConstant>0.0</timeConstant>
         </dynamics>
 
-        <!-- Yoerger's nonlinear dynamic model
+        <!-- Yoerger nonlinear dynamic model
         For information on the model description:
         [1] D. R. Yoerger, J. G. Cooke, and J.-J. E. Slotine, "The influence of
             thruster dynamics on underwater vehicle behavior and their incorporation
@@ -129,7 +129,7 @@
           <beta>0.0</beta>
         </dynamics>
 
-        <!-- Bessa's nonlinear dynamic model
+        <!-- Bessa nonlinear dynamic model
         For information on the model description:
         [2] Bessa, Wallace Moreira, Max Suell Dutra, and Edwin Kreuzer. "Thruster
             dynamics compensation for the positioning of underwater robotic vehicles
@@ -180,8 +180,8 @@
         </conversion>
 
         <!-- Linear interpolation
-        If you have access to the thruster's data sheet, for example,
-        you can enter samples of the curve's input and output values
+        If you have access to the thruster data sheet, for example,
+        you can enter samples of the curve input and output values
         and the thruster output will be found through linear interpolation
         of the given samples.
         -->

--- a/uuv_tutorials/uuv_tutorial_rov_model/urdf/rov_example_thrusters.xacro
+++ b/uuv_tutorials/uuv_tutorial_rov_model/urdf/rov_example_thrusters.xacro
@@ -26,7 +26,7 @@
     <!--
     Important:
         - The thruster IDs must be given as integers and must be unique to each thruster unit
-        - The thruster pose in the <origin> block is relative to the body's center of mass. Be
+        - The thruster pose in the <origin> block is relative to the body center of mass. Be
           aware that Gazebo does not use the SNAME convention per default.
     -->
 


### PR DESCRIPTION
Hi, 

As seen in ros2/launch_ros#214 and ros2/launch_ros/issues/136 launch files may have trouble getting the output of a `xacro` command if the parsed xacro files contain special YAML characters (typically apostrophes / colons inside comments). 

The launch file examples of Plankton use the `OpaqueFunction` approach that explicitly runs `xacro` to generate a temporary URDF file. On the other hand, if the `Command` substitution is used (which is a common practice) then it fails on the current xacro files from Plankton.

This PR simply removes the apostrophes in the comments, following the same workaround as other people did.