### PR TITLE
Fix gazebo_ros/node.hpp not found issue when building uuv_gazebo_ros_plugins

### DIFF
--- a/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/CMakeLists.txt
+++ b/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(gazebo_dev REQUIRED)
+find_package(gazebo_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -25,6 +26,7 @@ find_package(visualization_msgs REQUIRED)
 set(BASE_LIBS  
   ament_cmake 
   gazebo_dev
+  gazebo_ros
   geometry_msgs 
   rclcpp 
   sensor_msgs 


### PR DESCRIPTION
Hi Plankton authors,

Thanks for this great work on this project. I'm sure many developers of `uuv_simulator` would find Plankton useful in a ROS2 environment.

Re: this pull request, I noticed the issue attached in the image below when building Plankton via `colcon build --packages-up-to plankton`. I believe the inclusion of `gazebo_dev` package dependency alone isn't enough to make CMake/Ament include `gazebo_ros` headers that the package `uuv_gazebo_ros_plugins` depends on. This is addressed by including `gazebo_ros` in the package's CMakeLists.txt, which lets the package to build with appropriate includes from say `/opt/ros/foxy/include/gazebo_ros`.

![uuv_gazebo_ros_plugins_build_error](https://user-images.githubusercontent.com/832003/124079188-6a0cfa00-da7b-11eb-8a75-bdf92eeacbb9.png)

Let me know what you think.

System environment details:
OS: Ubuntu 20.04
ROS2 version: Foxy
Gazebo version: 11

Cheers.
Ashish