### PR TITLE
Fix JointStatePublisher plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .idea
 .ropeproject
 .imdone
+CMakeLists.txt.user
 
 # Misc
 .clang_complete

--- a/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/include/uuv_gazebo_ros_plugins/JointStatePublisher.h
+++ b/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/include/uuv_gazebo_ros_plugins/JointStatePublisher.h
@@ -57,8 +57,6 @@ class JointStatePublisher : public gazebo::ModelPlugin
 
   public: void PublishJointStates();
 
-  private: bool IsIgnoredJoint(std::string _jointName);
-
   private: gazebo::physics::WorldPtr world;
 
   private: gazebo::physics::ModelPtr myModel;
@@ -69,8 +67,6 @@ class JointStatePublisher : public gazebo::ModelPlugin
 
   private: std::string myRobotNamespace;
 
-  private: std::vector<std::string> movingJoints;
-
   private: double updateRate;
 
   private: double updatePeriod;
@@ -78,6 +74,9 @@ class JointStatePublisher : public gazebo::ModelPlugin
   private: gazebo::common::Time lastUpdate;
 
   private: rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr myJointStatePub;
+
+  private: sensor_msgs::msg::JointState jointState;
+  private: size_t moving_joints{0};
 };
 }
 

--- a/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/src/JointStatePublisher.cpp
+++ b/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/src/JointStatePublisher.cpp
@@ -30,8 +30,8 @@ GZ_REGISTER_MODEL_PLUGIN(JointStatePublisher)
 ///////////////////////////////////////////////////////////////////////////////
 JointStatePublisher::JointStatePublisher()
 {
-    myModel = NULL;
-    this->world = NULL;
+  myModel = NULL;
+  this->world = NULL;
 }
 
 //=============================================================================
@@ -39,13 +39,13 @@ JointStatePublisher::JointStatePublisher()
 JointStatePublisher::~JointStatePublisher()
 {
   //rclcpp::shutdown();
-    //this->node->shutdown();
+  //this->node->shutdown();
 }
 
 //=============================================================================
 ///////////////////////////////////////////////////////////////////////////////
 void JointStatePublisher::Load(gazebo::physics::ModelPtr _parent,
-  sdf::ElementPtr _sdf)
+                               sdf::ElementPtr _sdf)
 {
   myModel = _parent;
 
@@ -77,37 +77,51 @@ void JointStatePublisher::Load(gazebo::physics::ModelPtr _parent,
   else
     gzmsg << "JointStatePublisher::robot namespace = " << myRosNode->get_namespace() << std::endl;
 
-
-  // if (myRobotNamespace[0] != '/')
-  //   myRobotNamespace = "/" + myRobotNamespace;
-
   if (_sdf->HasElement("updateRate"))
     this->updateRate = _sdf->Get<double>("updateRate");
   else
     this->updateRate = 50;
 
-  gzmsg << "JointStatePublisher::Retrieving moving joints:" << std::endl;
-  this->movingJoints.clear();
-  double upperLimit, lowerLimit;
+  const auto FIXED_JOINT{gazebo::physics::Base::EntityType::FIXED_JOINT
+                        + gazebo::physics::Base::EntityType::JOINT};
+
+  std::set<std::string> moving_joint_names;
+
   for (auto &joint : myModel->GetJoints())
   {
+    // do not consider fixed joints
+    if (joint->GetType() == FIXED_JOINT)
+      continue;
+
+    jointState.name.push_back(joint->GetName());
+    
+
 #if GAZEBO_MAJOR_VERSION >= 8
-  lowerLimit = joint->LowerLimit(0);
-  upperLimit = joint->UpperLimit(0);
+      const auto lowerLimit{joint->LowerLimit(0)};
+      const auto upperLimit{joint->UpperLimit(0)};
 #else
-  lowerLimit = joint->GetLowerLimit(0).Radian();
-  upperLimit = joint->GetUpperLimit(0).Radian();
+      const auto lowerLimit{joint->GetLowerLimit(0).Radian()};
+      const auto upperLimit{joint->GetUpperLimit(0).Radian()};
 #endif
-    if (lowerLimit  == 0 && upperLimit == 0)
-      continue;
-    else if (joint->GetType() == gazebo::physics::Base::EntityType::FIXED_JOINT)
-      continue;
-    else
-    {
-      this->movingJoints.push_back(joint->GetName());
-      gzmsg << "\t- " << joint->GetName() << std::endl;
-    }
+
+      if (lowerLimit == 0. && upperLimit == 0.)
+      {
+        gzmsg << "\t- " << joint->GetName() << " (0-bounded)" << std::endl;
+        continue;
+      }
+
+    moving_joint_names.insert(joint->GetName());
+    moving_joints++;
+    gzmsg << "\t- " << joint->GetName() << std::endl;
   }
+
+  const auto nJoints{jointState.name.size()};
+  jointState.position.resize(nJoints, 0);
+  jointState.velocity.resize(nJoints, 0);
+
+  // put moving joints in front, we only care about them
+  std::partition(jointState.name.begin(), jointState.name.end(), [&](const auto &name)
+  {return moving_joint_names.find(name) != moving_joint_names.end();});
 
   GZ_ASSERT(this->updateRate > 0, "Update rate must be positive");
 
@@ -116,8 +130,8 @@ void JointStatePublisher::Load(gazebo::physics::ModelPtr _parent,
 
   // Advertise the joint states topic
   myJointStatePub =
-    myRosNode->create_publisher<sensor_msgs::msg::JointState>(
-      /*myRobotNamespace +*/ "joint_states", 1);
+      myRosNode->create_publisher<sensor_msgs::msg::JointState>(
+        /*myRobotNamespace +*/ "joint_states", 1);
 #if GAZEBO_MAJOR_VERSION >= 8
   this->lastUpdate = this->world->SimTime();
 #else
@@ -125,7 +139,7 @@ void JointStatePublisher::Load(gazebo::physics::ModelPtr _parent,
 #endif
   // Connect the update function to the Gazebo callback
   this->updateConnection = gazebo::event::Events::ConnectWorldUpdateBegin(
-    std::bind(&JointStatePublisher::OnUpdate, this, std::placeholders::_1));
+                             std::bind(&JointStatePublisher::OnUpdate, this, std::placeholders::_1));
 }
 
 //=============================================================================
@@ -148,51 +162,25 @@ void JointStatePublisher::OnUpdate(const gazebo::common::UpdateInfo & /*_info*/)
 ///////////////////////////////////////////////////////////////////////////////
 void JointStatePublisher::PublishJointStates()
 {
-  sensor_msgs::msg::JointState jointState;
 
   jointState.header.stamp = myRosNode->get_clock()->now();
-  // Resize containers
-  jointState.name.resize(myModel->GetJointCount());
-  jointState.position.resize(myModel->GetJointCount());
-  jointState.velocity.resize(myModel->GetJointCount());
-  jointState.effort.resize(myModel->GetJointCount());
 
-  int i = 0;
-  for (auto &joint : myModel->GetJoints())
+  // only first moving_joints are moving
+  for (size_t i = 0; i < moving_joints; ++i)
   {
-    if (!this->IsIgnoredJoint(joint->GetName()))
-    {
-      jointState.name[i] = joint->GetName();
+    const auto & joint{myModel->GetJoint(jointState.name[i])};
+
 #if GAZEBO_MAJOR_VERSION >= 8
       jointState.position[i] = joint->Position(0);
 #else
       jointState.position[i] = joint->GetAngle(0).Radian();
 #endif
       jointState.velocity[i] = joint->GetVelocity(0);
-      jointState.effort[i] = joint->GetForce(0);
+      // not implemented anyway
+      // jointState.effort[i] = joint.GetForce(0);
     }
-      else
-    {
-      jointState.name[i] = joint->GetName();
-      jointState.position[i] = 0.0;
-      jointState.velocity[i] = 0.0;
-      jointState.effort[i] = 0.0;
-    }
-
-    ++i;
-  }
 
   myJointStatePub->publish(jointState);
 }
 
-//=============================================================================
-///////////////////////////////////////////////////////////////////////////////
-bool JointStatePublisher::IsIgnoredJoint(std::string _jointName)
-{
-  if (this->movingJoints.empty()) return true;
-  for (auto joint : this->movingJoints)
-    if (_jointName.compare(joint) == 0)
-      return false;
-  return true;
-}
 }

--- a/uuv_gazebo_worlds/config/auv_underwater_world.yaml
+++ b/uuv_gazebo_worlds/config/auv_underwater_world.yaml
@@ -2,7 +2,7 @@ publish_world_models:
   ros__parameters:
     meshes:
       sea_surface:
-        mesh: package://uuv_gazebo_worlds/Media/models/sea_surface_1000m_x_1000m.dae
+        mesh: package://uuv_gazebo_worlds/media/models/sea_surface_1000m_x_1000m.dae
         model: sea_surface
         scale: [2., 2., 1.]
       sea_bottom:

--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/PoseGTROSPlugin.cpp
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/src/PoseGTROSPlugin.cpp
@@ -130,54 +130,18 @@ bool PoseGTROSPlugin::OnUpdate(const common::UpdateInfo& _info)
   if (dt <= 0)
     return false;
 
-  ignition::math::Pose3d linkPose, refLinkPose;
-  ignition::math::Vector3d refLinVel, refAngVel;
-  ignition::math::Vector3d linkLinVel, linkAngVel;
-
   this->UpdateNEDTransform();
   // Read sensor link's current pose and velocity
 #if GAZEBO_MAJOR_VERSION >= 8
-  linkLinVel = this->link->WorldLinearVel();
-  linkAngVel = this->link->WorldAngularVel();
+  auto linkLinVel = this->link->RelativeLinearVel();
+  auto linkAngVel = this->link->RelativeAngularVel();
 
-  linkPose = this->link->WorldPose();
+  const auto linkPose = this->link->WorldPose();
 #else
-  linkLinVel = this->link->GetWorldLinearVel().Ign();
-  linkAngVel = this->link->GetWorldAngularVel().Ign();
-
-  linkPose = this->link->GetWorldPose().Ign();
+  auto linkLinVel = this->link->GetRelativeLinearVel().Ign();
+  auto linkAngVel = this->link->GetRelativeAngularVel().Ign();
+  const auto linkPose = this->link->GetWorldPose().Ign();
 #endif
-
-  this->UpdateReferenceFramePose();
-
-  // Update the reference frame in case it is given as a Gazebo link and
-  // read the reference link's linear and angular velocity vectors
-  if (this->referenceLink)
-  {
-#if GAZEBO_MAJOR_VERSION >= 8
-    refLinVel = this->referenceLink->WorldLinearVel();
-    refAngVel = this->referenceLink->WorldAngularVel();
-
-    this->referenceFrame = this->referenceLink->WorldPose();
-#else
-    refLinVel = this->referenceLink->GetWorldLinearVel().Ign();
-    refAngVel = this->referenceLink->GetWorldAngularVel().Ign();
-
-    this->referenceFrame = this->referenceLink->GetWorldPose().Ign();
-#endif
-  }
-  else
-  {
-    // If no Gazebo link is given as a reference, the linear and angular
-    // velocity vectors are set to zero
-    refLinVel = ignition::math::Vector3d::Zero;
-    refAngVel = ignition::math::Vector3d::Zero;
-  }
-
-  // Transform pose and velocity vectors to be represented wrt the
-  // reference link provided
-  linkLinVel -= refLinVel;
-  linkAngVel -= refAngVel;
 
   // Add noise to the link's linear velocity
   linkLinVel += ignition::math::Vector3d(


### PR DESCRIPTION
The current JointStatePublisher plugin was not correctly ignoring fixed joints.

While they are not used historically in UUV / Plankton, they can be used instead of all the 0-bounded joints used for examples to define the sensor frames. Using revolute joints with 0-limits has two limitations:
 - it increases the [load on the physics engine](https://answers.gazebosim.org/question/6944/urdf-joints-not-appearing-in-gazebo/?answer=6945#post-id-6945)
 - it makes it more difficult to use the robot model outside of Plankton, as these joint values are not published (or we have to use a custom publisher)

Additionally, a new tag <only_actuators> is available for the JointStatePublisher plugin. If this is true then only 0-bounded joints and joints containing _fin_ or _thruster_ will be published. Indeed, if a UUV has e.g. a moving camera, the corresponding joint will be controlled / published from a classical _ros2_control_ approach (that can also work on the vehicle).