### PR TITLE
Corrections to sonar sensor plugin name

### DIFF
--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/urdf/sonar_snippets.xacro
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/urdf/sonar_snippets.xacro
@@ -157,7 +157,8 @@
           <stddev>${range_stddev}</stddev>
         </noise>
       </ray>
-      <plugin name="sonar${suffix}_controller" filename="libgazebo_ros_gpu_laser.so">
+      <plugin name="sonar${suffix}_controller" filename="libgazebo_ros_ray_sensor.so">
+        <namespace>${namespace}</namespace>
         <topicName>${topic}</topicName>
         <frameName>sonar${suffix}_link</frameName>
       </plugin>


### PR DESCRIPTION
Corrected the plugin name used for the definition of the sonar sensor as per instructions in this page:

https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-Migration%3A-Ray-sensors